### PR TITLE
Creative Common licence to Safe Network logos

### DIFF
--- a/src/containers/press_kit.js
+++ b/src/containers/press_kit.js
@@ -134,6 +134,7 @@ class Downloads extends React.Component {
           <div className="pkit-dwn-i">
             <h3 className="pkit-dwn-i-h">Safe Network Logo</h3>
             <p className="pkit-dwn-i-para">Logo pack containing both black and white logos in PNG, SVG and EPS formats.</p>
+            <p className="pkit-dwn-i-para">All SAFE Network logos and images are made available via <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution - ShareAlike 4.0</a></p>
             <button className="underline-btn" onClick={() => {
               window.open(CONST.links.pKit.download.logos)
             }}>Download logos</button>

--- a/src/sass/components/press_kit.sass
+++ b/src/sass/components/press_kit.sass
@@ -211,6 +211,11 @@
             +para()
             font-size: get-vw(18px)
             margin-bottom: 30px
+            a
+              text-decoration: none
+              color: $spark-red
+              &:hover
+                text-decoration: underline
           .underline-btn
             +font-bold()
             font-size: get-vw(18px)

--- a/test/broken_link_check.js
+++ b/test/broken_link_check.js
@@ -10,6 +10,7 @@ const scanForBrokenLinks = (serveUrl) => {
     excludedKeywords: [
       'https://www.cryptopia.co.nz/',
       'https://t.me/safenetwork',
+      'https://www.ico.org.uk/',
     ]
   };
   return new Promise((resolve, rejects) => {


### PR DESCRIPTION
Updated presskit page have Creative common licence licence for Safe Network logos.