### PR TITLE
Remove suggestion that no account is required to browse network

### DIFF
--- a/src/containers/get_involved.js
+++ b/src/containers/get_involved.js
@@ -40,7 +40,7 @@ class Community extends React.Component {
           <div className="get-inv-community-cntr2 get-inv-lay-cntr2 get-inv-cnt">
             <div className="get-inv-community-cntr2-b">
               <h3 className="get-inv-cnt-h2">Get the SAFE Browser</h3>
-              <p className="get-inv-cnt-para2">The SAFE Browser is the Network’s dedicated web browser. Use it to access the Alpha test network—just download and start browsing.</p>
+              <p className="get-inv-cnt-para2">The SAFE Browser is the Network’s dedicated web browser. To access the network while it is in Alpha you'll need to have a forum account with <a href="https://safenetforum.org/t/trust-level-1-basic-user-requirements/15200">basic trust level</a> and get an <a href="https://invite.maidsafe.net">invite token</a>.  Then just download and start browsing.</p>
               <a href={browserLink} className="get-inv-cnt-lnk-btn blue">Download Now</a>
             </div>
           </div>

--- a/src/containers/home.js
+++ b/src/containers/home.js
@@ -230,7 +230,7 @@ class NewEconomy extends React.Component {
                 <div className="sec-rgt-ii">
                   <Container2
                     head="Always Free to Access"
-                    para={['Information is always free to access. You’ll never be charged for browsing or downloading. The SAFE Network guarantees equal access to data for everyone. You don’t even need an account, just download the browser']}
+                    para={['Information is always free to access. You’ll never be charged for browsing or downloading. The SAFE Network guarantees equal access to data for everyone.']}
                   />
                 </div>
                 <div className="sec-rgt-iii">
@@ -287,7 +287,7 @@ class Security extends React.Component {
                 <div className="sec-rgt-i">
                   <Container2
                     head="Browse and access content anonymously"
-                    para={['On the SAFE Network, you are free to browse and download completely anonymously, from anywhere in the world. No account necessary.']}
+                    para={['On the SAFE Network, you are free to browse and download completely anonymously, from anywhere in the world.']}
                   />
                 </div>
                 <div className="sec-rgt-ii">

--- a/src/content/faqs.json
+++ b/src/content/faqs.json
@@ -88,11 +88,19 @@
         "q": "What do I need in order to browse the SAFE Network?",
         "a": [
           {
-            "cnt": "On the SAFE Network, you are free to browse SAFE Websites completely anonymously, from anywhere in the world.  To ensure security and anonymity we couldn't rely on existing browser technology used on the traditional internet (Chrome/FireFox/IE/Safari etc.) so we built our own.",
+            "cnt": "While the network is in Alpha you'll need an account.  See 'How do I create an account?' below for a step-by-step guide.",
             "type": "para"
           },
           {
-            "cnt": "All you'll need is our new *SAFE Browser* which you can download using the link below and then you are ready to start browsing the SAFE Network!",
+            "cnt": "Then all you need to do is [download the SAFE Browser](https://github.com/maidsafe/safe_browser/releases) and enter a SAFE site into the address bar and that's you browsing the SAFE Network.",
+            "type": "para"
+          },
+          {
+            "cnt": "Some sample SAFE sites (copy and paste the address into the SAFE Browser address bar):",
+            "type": "para"
+          },
+          {
+            "cnt": "<ul><li><a href='safe://maidsafe.safenet' target='_self'>safe://maidsafe.safenet</a></li><li><a href='safe://racer.game/v4.final.html' target='_self'>safe://racer.game/v4.final.html</a></li><li><a href='safe://hello' target='_self'>safe://hello</a></li></ul>",
             "type": "para"
           },
           {
@@ -106,27 +114,7 @@
         "q": "Do I need an account to access the network?",
         "a": [
           {
-            "cnt": "<b>Browsing the SAFE Network’s websites:</b>",
-            "type": "para"
-          },
-          {
-            "cnt": "On the SAFE Network, you are free to browse and download from *SAFE Websites* completely anonymously, from anywhere in the world. No account necessary.",
-            "type": "para"
-          },
-          {
-            "cnt": "To get started simply [download the SAFE Browser](https://github.com/maidsafe/safe_browser/releases) and enter a SAFE site into the address bar.  Some sample SAFE sites:",
-            "type": "para"
-          },
-          {
-            "cnt": "<ol><li><a href='safe://www.sharedmap/' target='_self'>safe://www.sharedmap/</a></li><li><a href='safe://jams.demo2/' target='_self'>safe://jams.demo2/</a></li><li><a href='safe://listy/' target='_self'>safe://listy/</a></li></ol>",
-            "type": "para"
-          },
-          {
-            "cnt": "<b>Storing on the network:</b>",
-            "type": "para"
-          },
-          {
-            "cnt": "You’ll need an account to perform any action that requires putting new data or modifying existing data on the SAFE Network.  Activities that will require an account would include: <ul><li>hosting websites</li><li>file storage</li><li>email applications</li><li>instant messaging</li><li>etc.</li></ul>",
+            "cnt": "While the network is in Alpha then yes, you'll need to have an account.  See 'How do I create an account?' below for a step-by-step guide.",
             "type": "para"
           }
         ]

--- a/src/content/getInv_faq.json
+++ b/src/content/getInv_faq.json
@@ -6,24 +6,25 @@
         "q": "What do I need in order to browse the SAFE Network?",
         "a": [
           {
-            "cnt": "You need to download and install the SAFE Browser to connect to the network.",
+            "cnt": "While the network is in Alpha you'll need an account.  See 'How do I create an account?' below for a step-by-step guide.",
             "type": "para"
           },
           {
-            "cnt": "<b>To download:</b>",
+            "cnt": "Then all you need to do is [download the SAFE Browser](https://github.com/maidsafe/safe_browser/releases) and enter a SAFE site into the address bar and that's you browsing the SAFE Network.",
             "type": "para"
           },
           {
-            "cnt": "The latest version of the SAFE Browser is always available on GitHub here:<ul><li>https://github.com/maidsafe/safe_browser/releases/ </li></ul>",
+            "cnt": "Some sample SAFE sites (copy and paste the address into the SAFE Browser address bar):",
             "type": "para"
           },
           {
-            "cnt": "<b>To install:</b>",
+            "cnt": "<ul><li><a href='safe://maidsafe.safenet' target='_self'>safe://maidsafe.safenet</a></li><li><a href='safe://racer.game/v4.final.html' target='_self'>safe://racer.game/v4.final.html</a></li><li><a href='safe://hello' target='_self'>safe://hello</a></li></ul>",
             "type": "para"
           },
           {
-            "cnt": "<ol><li>Open your downloads folder.</li><li>Extract the contents of the ZIP you downloaded in the first stage (generally just double-clicking on the file will do it).</li><li>Move the file to where you want to keep it (Perhaps your Desktop).</li><li>Double-click the SAFE Browser app to open it and start browsing!</li></ol>",
-            "type": "para"
+            "cnt": "Get the SAFE Browser",
+            "type": "anchor",
+            "href": "https://github.com/maidsafe/safe_browser/releases/"
           }
         ]
       },
@@ -31,23 +32,7 @@
         "q": "Do I need an account to access the network?",
         "a": [
           {
-            "cnt": "It depends what you want to do.",
-            "type": "para"
-          },
-          {
-            "cnt": "<b>Browsing the SAFE Network’s websites:</b>",
-            "type": "para"
-          },
-          {
-            "cnt": "No account is required.  To view SAFE websites, all you need to do is to <a href='https://github.com/maidsafe/safe_browser/releases' target='_blank'>download the SAFE Browser</a> (currently available on Windows, Mac and Linux).",
-            "type": "para"
-          },
-          {
-            "cnt": "<b>Storing on the network:</b>",
-            "type": "para"
-          },
-          {
-            "cnt": "Yes, you’ll need an account to perform an action that requires storing any new data or modifying any existing data on the SAFE Network.  By 'storing' we mean activities like: <ul><li>hosting websites</li><li>file storage</li><li>email applications</li><li>instant messaging</li><li>etc.</li></ul>",
+            "cnt": "While the network is in Alpha then yes, you'll need to have an account.  See 'How do I create an account?' below for a step-by-step guide.",
             "type": "para"
           }
         ]


### PR DESCRIPTION
While in Alpha you always need an account in order to have generated an invitation token.  Currently text is suggesting otherwise.