### PR TITLE
Safecoin - link to OpenLedger not pointing at MaidSafe coin. #331

### DIFF
--- a/src/content/faqs.json
+++ b/src/content/faqs.json
@@ -415,7 +415,7 @@
             "type": "para"
           },
           {
-            "cnt": "MaidSafeCoin is listed on the bitcoin blockchain and can be purchased on a number of exchanges including:<ul><li>[Poloniex](https://www.poloniex.com/exchange#btc_maid)</li><li>[HitBTC](https://hitbtc.com/MAID-to-BTC)</li><li>[Cryptopia](https://www.cryptopia.co.nz/)</li><li>[OpenLedger](https://openledger.io/welcome)</li><li>[Bitker](https://www.bitker01.com/#/bbTrades/maid_btc)</li></ul>",
+            "cnt": "MaidSafeCoin is listed on the bitcoin blockchain and can be purchased on a number of exchanges including:<ul><li>[Poloniex](https://www.poloniex.com/exchange#btc_maid)</li><li>[HitBTC](https://hitbtc.com/MAID-to-BTC)</li><li>[Cryptopia](https://www.cryptopia.co.nz/Exchange/?market=MAID_BTC)</li><li>[OpenLedger](https://openledger.io/market/MAID_BTC)</li><li>[Bitker](https://www.bitker01.com/#/bbTrades/maid_btc)</li></ul>",
             "type": "para"
           },
           {
@@ -487,7 +487,7 @@
             "type": "para"
           },
           {
-            "cnt": "MaidSafeCoin is listed on the bitcoin blockchain and can be purchased on a number of exchanges including [Poloniex](https://www.poloniex.com/exchange#btc_maid), [HitBTC](https://hitbtc.com/MAID-to-BTC), [Cryptopia](https://www.cryptopia.co.nz/), [OpenLedger](https://openledger.io/welcome) and [Bitker](https://www.bitker01.com/#/bbTrades/maid_btc)",
+            "cnt": "MaidSafeCoin is listed on the bitcoin blockchain and can be purchased on a number of exchanges including [Poloniex](https://www.poloniex.com/exchange#btc_maid), [HitBTC](https://hitbtc.com/MAID-to-BTC), [Cryptopia](https://www.cryptopia.co.nz/Exchange/?market=MAID_BTC), [OpenLedger](https://openledger.io/market/MAID_BTC) and [Bitker](https://www.bitker01.com/#/bbTrades/maid_btc)",
             "type": "para"
           }
         ]

--- a/src/content/safecoins_faq.json
+++ b/src/content/safecoins_faq.json
@@ -57,7 +57,7 @@
         "q": "What is MaidSafeCoin?",
         "a": [
           {
-            "cnt": "MaidSafeCoin is a proxy token that was released during MaidSafe's crowd sale and will be swapped for Safecoin on a 1:1 basis when Safecoin is released. MaidSafeCoin is listed on the bitcoin blockchain and can be purchased on a number of exchanges including:<ul><li>[Poloniex](https://www.poloniex.com/exchange#btc_maid)</li><li>[HitBTC](https://hitbtc.com/MAID-to-BTC)</li><li>[Cryptopia](https://www.cryptopia.co.nz/)</li><li>[OpenLedger](https://openledger.io/welcome)</li><li>[Bitker](https://www.bitker01.com/#/bbTrades/maid_btc)</li></ul>",
+            "cnt": "MaidSafeCoin is a proxy token that was released during MaidSafe's crowd sale and will be swapped for Safecoin on a 1:1 basis when Safecoin is released. MaidSafeCoin is listed on the bitcoin blockchain and can be purchased on a number of exchanges including:<ul><li>[Poloniex](https://www.poloniex.com/exchange#btc_maid)</li><li>[HitBTC]({https://hitbtc.com/MAID-to-BTC})</li><li>[Cryptopia](https://www.cryptopia.co.nz/Exchange/?market=MAID_BTC)</li><li>[OpenLedger](https://openledger.io/market/MAID_BTC)</li><li>[Bitker](https://www.bitker01.com/#/bbTrades/maid_btc)</li></ul>",
             "type": "para"
           }
         ]


### PR DESCRIPTION
Update links in FAQ to point to the correct markets in the OpenLedger and Cryptopia exchanges .