### PR TITLE
exclude Bittrex from broken link checker

### DIFF
--- a/test/broken_link_check.js
+++ b/test/broken_link_check.js
@@ -10,7 +10,8 @@ const scanForBrokenLinks = (serveUrl) => {
       'https://t.me/safenetwork',
       'https://youtu.be',
       'https://www.youtube.com',
-      'https://www.chainrift.com'
+      'https://www.chainrift.com',
+      'https://global.bittrex.com'
     ],
   };
   return new Promise((resolve, rejects) => {


### PR DESCRIPTION
This makes the CI pass again.