### PR TITLE
Update Roadmap page (Baby Fleming iteration 3) and Get Involved page

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "html-to-react": "^1.4.2",
     "markdown-it": "^10.0.0",
     "react-device-detect": "^1.11.14",
-    "react-lazyload": "^2.6.5",
+    "react-lazyload": "^2.6.6",
     "react-router-dom": "^5.1.2",
     "react-router-hash-link": "^1.2.2",
     "react-static": "7.1.0",

--- a/src/constant.js
+++ b/src/constant.js
@@ -23,12 +23,12 @@ export default {
   },
   downloadApps: {
     browser: {
-      mac: 'https://github.com/maidsafe/safe_browser/releases/download/v0.16.0/safe-browser-v0.16.0-mac-x64.dmg',
-      windows: 'https://github.com/maidsafe/safe_browser/releases/download/v0.16.0/safe-browser-v0.16.0-win-x64.exe',
-      linux: 'https://github.com/maidsafe/safe_browser/releases/download/v0.16.0/safe-browser-v0.16.0-linux-x64.AppImage',
-      android: 'https://github.com/maidsafe/safe_browser/releases/latest',
-      ios: 'https://github.com/maidsafe/safe_browser/releases/latest',
-      others: 'https://github.com/maidsafe/safe_browser/releases/latest',
+      mac: 'https://github.com/maidsafe/safe_browser/releases/download/v0.17.0-alpha.1/safe-browser-v0.17.0-alpha.1-mac-x64.dmg',
+      windows: 'https://github.com/maidsafe/safe_browser/releases/download/v0.17.0-alpha.1/safe-browser-v0.17.0-alpha.1-win-x64.exe',
+      linux: 'https://github.com/maidsafe/safe_browser/releases/download/v0.17.0-alpha.1/safe-browser-v0.17.0-alpha.1-linux-x64.AppImage',
+      android: 'https://github.com/maidsafe/safe_browser/releases/tag/v0.17.0-alpha.1',
+      ios: 'https://github.com/maidsafe/safe_browser/releases/tag/v0.17.0-alpha.1',
+      others: 'https://github.com/maidsafe/safe_browser/releases/tag/v0.17.0-alpha.1',
     }
   },
 

--- a/src/pages/GetInvolved/content.js
+++ b/src/pages/GetInvolved/content.js
@@ -63,12 +63,16 @@ export default {
     title: 'Get Started',
     joinNetwork: {
       id: 'joinNetwork',
-      title: 'Try out the Phase 1 Vault Release',
-      para: 'It’s easy to use. Just download a Vault binary which will run locally on your computer. Or use the public shared Vault we’ve set up.',
+      title: 'Connect to the Baby Fleming Public Shared Section',
+      para: 'This shared section is hosted on DigitalOcean and consists of eight vaults on eight separate droplets, all connected together in one section. Please note that this testnet may require to be taken down.',
       CTA: {
         button: {
           name: 'Learn more',
-          url: 'https://safenetforum.org/t/new-release-vault-phase-1-real-vault/29712'
+          url: 'https://safenetforum.org/t/baby-fleming-public-shared-section/31377'
+        },
+        link: {
+          name: 'CLI User Guide',
+          url: 'https://github.com/maidsafe/safe-api/blob/master/safe-cli/README.md#download'
         }
       }
     },

--- a/src/pages/Roadmap/content.js
+++ b/src/pages/Roadmap/content.js
@@ -4,12 +4,12 @@ export default {
     pageDesc: `14 years of research and development is coming to fruition as we put together the final building blocks of what some said was impossible: Secure Access For Everyone.`,
     latestUpdate: {
       overline: 'Latest Update',
-      date: 'March 19, 2020',
-      title: 'Baby Fleming iteration 2',
-      para: `The Baby Fleming release is about iterating from a single vault network into a multiple vaults (single-section) network. Iteration 2 contains the removal of the PARSEC step from the client request-processing flow.`,
+      date: 'March 26, 2020',
+      title: 'Baby Fleming iteration 3',
+      para: `The Baby Fleming release is about iterating from a single vault network into a multiple vaults (single-section) network. Iteration 3 has been updated to use the latest version of the Quinn library (via quic-p2p).`,
        CTA: {
          name: 'SAFE Network Forum',
-         url: 'https://safenetforum.org/t/safe-network-dev-update-march-19-2020/31311'
+         url: 'https://safenetforum.org/t/safe-network-dev-update-march-26-2020/31360'
        }
     }
   },
@@ -22,7 +22,7 @@ export default {
       title: 'Baby Fleming Network',
       para:[
         `From a user perspective, the exact same type of operations and use cases as Vaults Phase 1 are being supported by Baby Fleming, i.e. Test Safecoin, wallets, files, NRS names, SAFE sites, etc.`,
-        'We’ll soon set up a public shared network for you to play with, but for now you’ll need to set up your own local network. See the [CLI User Guide](https://github.com/maidsafe/safe-api/blob/master/safe-cli/README.md#description) for full instructions on installing the SAFE CLI, the Authenticator daemon, the Vault binary and running your own section of vaults on your platform.'
+        'We’ve set up a [public shared section](https://safenetforum.org/t/baby-fleming-public-shared-section/31377) for you to play with. You can also set up your own local network. See the [CLI User Guide](https://github.com/maidsafe/safe-api/blob/master/safe-cli/README.md#download) for full instructions.'
       ],
       // accordion: {
       //   header: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7494,10 +7494,10 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-react-lazyload@^2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-2.6.5.tgz#7a5ac001f0f8aeddc10c30e4ce318c10f13aa723"
-  integrity sha512-C/juO9l7dGS7jEARBLjM3oG7F1lL5bqajz/55sk3GFc0Ippd9vnSkdRxdiaE6gf5si3YxIow8dSJ+YuB2D/3vg==
+react-lazyload@^2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-2.6.6.tgz#3e1b0122b7b505cef88984b4ef5428b28dea1be9"
+  integrity sha512-waNTEToArDTMOnSWsZMYZID6+CT2xz+Hs/e4XpyAtESYBQs2L6moKYbcA4BbI6l5/ZueQQrLB+OhINL7SHmAOw==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Now that the Phase 1 Vault is about to be taken offline, I updated the Get Involved page to point to the new Public Shared Section and to the latest Browser alpha release (v0.17.0-alpha.1) since that's the only one currently compatible with Baby Fleming iteration 3.